### PR TITLE
Adds Bios Settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,26 @@ CPU正常睿频
 
 # 3.bios 设置参考指南   
 
+Enable :
+
+SATA Operation : AHCI
+
+XHCI Hand-Off
+
+Disable :
+
+Secure Boot
+
+Intel SGX
+
+Fastboot
+
+CFG LOCK
+
+Boot From Onboard LAN
+
+CSM (Most Important)
+
 https://www.bilibili.com/read/cv7393476
 
 


### PR DESCRIPTION
EFI for Asrock Z490M ITX/ac is your most stable than any recently updated. It deserves the most stars.
However, it is unfortunate that information related to BIOS setting is only provided as a link.
So, we request modification to the following items referenced in other repo.
Disabling CSM (UEFI Only) is the most important.
If CSM is activated by mistake, it will get stuck with "AppleNVMe Assert failed" message and unable to proceed further.
Spent a day not knowing that CSM was enabled by itself in the BIOS.